### PR TITLE
Change from using node.domain to node['domain'] incase 'domain' is not available.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,8 +20,8 @@
 
 default['ssmtp']['mailhub_name'] = 'localhost'
 default['ssmtp']['mailhub_port'] = 587
-default['ssmtp']['hostname'] = node.hostname
-default['ssmtp']['rewrite_domain'] = node.domain
+default['ssmtp']['hostname'] = node['hostname']
+default['ssmtp']['rewrite_domain'] = node['domain']
 
 default['ssmtp']['from_line_override'] = true
 


### PR DESCRIPTION
This enables the default recipe to work when there is no domain found from Ohai. For example in a Amazon EC2 instance running from VPC.
