### PR TITLE
Added use_tls attribute and enabled its use in the ssmtp.conf template

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,3 +32,4 @@ default['ssmtp']['auth_method'] = false
 default['ssmtp']['auth_username'] = false
 default['ssmtp']['auth_password'] = false
 default['ssmtp']['use_starttls'] = true
+default['ssmtp']['use_tls'] = true

--- a/templates/default/ssmtp.conf.erb
+++ b/templates/default/ssmtp.conf.erb
@@ -25,11 +25,18 @@ rewriteDomain=<%= node['ssmtp']['rewrite_domain'] %>
 FromLineOverride=YES
 <% end %>
 
-<% if node['ssmtp']['use_starttls'] %>
+<% if node['ssmtp']['use_starttls'] || node['ssmtp']['use_tls'] %>
 # Use SSL/TLS to send secure messages to server.
+<% end -%>
+<% if node['ssmtp']['use_starttls'] %>
 UseSTARTTLS=YES
 <% else %>
 UseSTARTTLS=NO
+<% end %>
+<% if node['ssmtp']['use_tls'] %>
+UseTLS=YES
+<% else %>
+UseTLS=NO
 <% end %>
 
 # user/pass used to connect to the MTA


### PR DESCRIPTION
This will help when connecting to Amazon SES servers over port 465.

See: http://www.bbck.net/blog/2011/12/18/ssmtp-and-amazon-ses
