### PR TITLE
Added support for RHEL family distros

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,3 +7,6 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.0"
 supports         "debian"
 supports         "ubuntu"
+supports         "centos"
+
+depends 'yum'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,10 @@
 # limitations under the License.
 #
 
+if platform?('redhat', 'centos', 'fedora')
+    include_recipe 'yum::epel'
+end
+
 package "ssmtp" do
   action :upgrade
 end


### PR DESCRIPTION
Notes:
- Tested & working on: Centos 5.9 & 6.4, Ubuntu 10.04 & 12.04
- Tested & broken on : Fedora *
  `yum::epel` cookbook does not yet support fedora due to broken
  mirrorlist url:
  "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-#{node['platform_version'].to_i}&arch=$basearch"
  should be:
  "http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-#{node['platform_version'].to_i}&arch=$basearch"
  when platform == 'fedora'
- Only added 'centos' to official metadata support list, as I did not
  test RedHat
