### PR TITLE
Auth enabling/disabling and a bit of cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+AllCops:
+  Excludes:
+    - bin/**
+    - vendor/**
+    - attributes/**
+    - Cheffile
+    - Berksfile
+    - metadata.rb
+    - cookbooks/**
+
+LineLength:
+  Max: 100
+MethodLength:
+  Max: 30

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Here's an example role:
 For a full list of attributes please consult `./attributes/default.rb`.
 
 #### Authentication
+
+By default this cookbook will use authentication. If you are relying on connecting to your mailhub without providing credentials disable authentication all together by setting node['ssmtp']['auth_enabled'] to false.
 	
 The cookbook provides an attribute called `credential_method` which defines whether authentication credentials are provided in a crypted data bag or via plain text. It defaults to the more secure crypto data bag method.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For a full list of attributes please consult `./attributes/default.rb`.
 
 #### Authentication
 
-By default this cookbook will use authentication. If you are relying on connecting to your mailhub without providing credentials disable authentication all together by setting node['ssmtp']['auth_enabled'] to false.
+By default this cookbook will use authentication. If you are relying on connecting to your mailhub without providing credentials disable authentication all together by setting `auth_enabled` to false.
 	
 The cookbook provides an attribute called `credential_method` which defines whether authentication credentials are provided in a crypted data bag or via plain text. It defaults to the more secure crypto data bag method.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,8 +28,9 @@ default['ssmtp']['from_line_override'] = true
 default['ssmtp']['credential_method'] = 'data_bag'         # or plain
 
 default['ssmtp']['root'] = false
+default['ssmtp']['auth_enabled'] = true
 default['ssmtp']['auth_method'] = false
-default['ssmtp']['auth_username'] = nil
-default['ssmtp']['auth_password'] = nil
+default['ssmtp']['auth_username'] = false
+default['ssmtp']['auth_password'] = false
 default['ssmtp']['use_starttls'] = true
 default['ssmtp']['use_tls'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,7 @@ default['ssmtp']['credential_method'] = 'data_bag'         # or plain
 
 default['ssmtp']['root'] = false
 default['ssmtp']['auth_method'] = false
-default['ssmtp']['auth_username'] = false
-default['ssmtp']['auth_password'] = false
+default['ssmtp']['auth_username'] = nil
+default['ssmtp']['auth_password'] = nil
 default['ssmtp']['use_starttls'] = true
 default['ssmtp']['use_tls'] = true

--- a/files/default/spec/default_test.rb
+++ b/files/default/spec/default_test.rb
@@ -1,9 +1,10 @@
+# encoding: utf-8
 describe_recipe 'ssmtp:default' do
   it 'installs ssmtp' do
-    package("ssmtp").must_be_installed
+    package('ssmtp').must_be_installed
   end
 
   it 'should create ssmtp.conf' do
-    file("/etc/ssmtp/ssmtp.conf").must_exist.with(:owner, "root").and(:group, "mail").and(:mode, 0640)
+    file('/etc/ssmtp/ssmtp.conf').must_exist.with(:owner, 'root').and(:group, 'mail').and(:mode, 0640)
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 #
 # Cookbook Name:: ssmtp
 # Recipe:: default
@@ -18,11 +19,9 @@
 # limitations under the License.
 #
 
-if platform?('redhat', 'centos', 'fedora')
-  include_recipe 'yum::epel'
-end
+include_recipe 'yum::epel' if platform?('redhat', 'centos', 'fedora')
 
-package "ssmtp" do
+package 'ssmtp' do
   action :upgrade
 end
 
@@ -36,12 +35,12 @@ when 'plain'
   password = node['ssmtp']['auth_password']
 end
 
-template "/etc/ssmtp/ssmtp.conf" do
-  source "ssmtp.conf.erb"
-  owner "root"
-  group "mail"
+template '/etc/ssmtp/ssmtp.conf' do
+  source 'ssmtp.conf.erb'
+  owner 'root'
+  group 'mail'
   mode  0640
   variables(
-    :auth_username    => username,
-    :auth_password    => password)
+    'auth_username'    => username,
+    'auth_password'    => password)
 end

--- a/templates/default/ssmtp.conf.erb
+++ b/templates/default/ssmtp.conf.erb
@@ -39,7 +39,7 @@ UseTLS=YES
 UseTLS=NO
 <% end %>
 
-<% if @auth_username %>
+<% if node['ssmtp']['auth_enabled'] %>
 # user/pass used to connect to the MTA
 AuthUser=<%= @auth_username %>
 AuthPass=<%= @auth_password %>


### PR DESCRIPTION
Hi,

I took the liberty to implement a bit cleaner way of enabling or disabling the auth all together by setting an attribute (auth_enabled, default true).

I also added a bit of rubocop compliance and a notice on the readme about the auth change.
