### PR TITLE
Add TLS_CA_File to SSMTP configuration file for RHEL/CentOS

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,3 +38,4 @@ default['ssmtp']['auth_username'] = false
 default['ssmtp']['auth_password'] = false
 default['ssmtp']['use_starttls'] = true
 default['ssmtp']['use_tls'] = true
+default['ssmtp']['tls_ca_file'] = '/etc/pki/tls/certs/ca-bundle.crt'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures ssmtp'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/svanzoest-cookbooks/ssmtp/issues'
 source_url 'https://github.com/svanzoest-cookbooks/ssmtp/'
-version '0.4.1'
+version '0.4.2'
 supports 'debian'
 supports 'ubuntu'
 supports 'centos'

--- a/templates/default/ssmtp.conf.erb
+++ b/templates/default/ssmtp.conf.erb
@@ -27,6 +27,10 @@ FromLineOverride=YES
 
 <% if node['ssmtp']['use_starttls'] || node['ssmtp']['use_tls'] %>
 # Use SSL/TLS to send secure messages to server.
+<% if %w[rhel fedora].include?(node['platform_family']) -%>
+# Locates CA as in Bug #1004998 (https://bugzilla.redhat.com/show_bug.cgi?id=1004998)
+TLS_CA_File=<%= node['ssmtp']['tls_ca_file'] %>
+<% end %>
 <% end -%>
 <% if node['ssmtp']['use_starttls'] %>
 UseSTARTTLS=YES
@@ -47,9 +51,4 @@ AuthPass=<%= @auth_password %>
 
 <% if node['ssmtp']['auth_method'] %>
 AuthMethod=<%= node['ssmtp']['auth_method'] %>
-<% end %>
-
-<% if %w[rhel fedora].include?(node['platform_family']) -%>
-# Locates CA as in Bug #1004998 (https://bugzilla.redhat.com/show_bug.cgi?id=1004998)
-TLS_CA_File=<%= node['ssmtp']['tls_ca_file'] %>
 <% end %>

--- a/templates/default/ssmtp.conf.erb
+++ b/templates/default/ssmtp.conf.erb
@@ -48,3 +48,8 @@ AuthPass=<%= @auth_password %>
 <% if node['ssmtp']['auth_method'] %>
 AuthMethod=<%= node['ssmtp']['auth_method'] %>
 <% end %>
+
+<% if %w[rhel fedora].include?(node['platform_family']) -%>
+# Locates CA as in Bug #1004998 (https://bugzilla.redhat.com/show_bug.cgi?id=1004998)
+TLS_CA_File=<%= node['ssmtp']['tls_ca_file'] %>
+<% end %>


### PR DESCRIPTION
As described in [this bug](https://bugzilla.redhat.com/show_bug.cgi?id=1004998), in recent ssmtp packages, with SSL/TLS enabled, a link to the `TLS_CA_File` is mandatory.

I have seen this problem only on recent Fedora and CentOS 7, so the added configuration is only for those platforms.
