### PR TITLE
Set TLS_CA_File for all platforms by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,4 +38,8 @@ default['ssmtp']['auth_username'] = false
 default['ssmtp']['auth_password'] = false
 default['ssmtp']['use_starttls'] = true
 default['ssmtp']['use_tls'] = true
-default['ssmtp']['tls_ca_file'] = '/etc/pki/tls/certs/ca-bundle.crt'
+
+default['ssmtp']['tls_ca_file'] = value_for_platform_family(
+  %w(rhel fedora) => '/etc/pki/tls/certs/ca-bundle.crt',
+  'default' => '/etc/ssl/certs/ca-certificates.crt'
+)

--- a/templates/default/ssmtp.conf.erb
+++ b/templates/default/ssmtp.conf.erb
@@ -27,8 +27,7 @@ FromLineOverride=YES
 
 <% if node['ssmtp']['use_starttls'] || node['ssmtp']['use_tls'] %>
 # Use SSL/TLS to send secure messages to server.
-<% if %w[rhel fedora].include?(node['platform_family']) -%>
-# Locates CA as in Bug #1004998 (https://bugzilla.redhat.com/show_bug.cgi?id=1004998)
+<% if node['ssmtp']['tls_ca_file'] -%>
 TLS_CA_File=<%= node['ssmtp']['tls_ca_file'] %>
 <% end %>
 <% end -%>


### PR DESCRIPTION
This is a cleaner rework of @sjourdan's pull request in #21 so kudos to him. It isn't clear whether this issue affects other platforms but it doesn't hurt to set it so let's do so just in case.
