### PR TITLE
Update hostname to use the fqdn ohai as source

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@
 
 default['ssmtp']['mailhub_name'] = 'localhost'
 default['ssmtp']['mailhub_port'] = 587
-default['ssmtp']['hostname'] = node['hostname']
+default['ssmtp']['hostname'] = node['fqdn']
 default['ssmtp']['rewrite_domain'] = node['domain']
 
 default['ssmtp']['from_line_override'] = true


### PR DESCRIPTION
# Description
If you don't use the rewrite_domain variable, the hostname is getting set as node.hostname - which causes outbound email to fail.  It can be overwritten by using a wrapper recipe, but it would be nice if the default was node.fqdn so that you could still just override with a role and not have to add an additional recipe/cookbook to wrap this one.

# How to test
Check that the /etc/ssmtp/ssmtp.conf file is written with an FQDN for the hostname variable.